### PR TITLE
fix decoder_ffmpeg build fail on macOS

### DIFF
--- a/libraries/decoder_ffmpeg/build.gradle
+++ b/libraries/decoder_ffmpeg/build.gradle
@@ -21,10 +21,10 @@ android.externalNativeBuild.cmake.version = '3.21.0+'
 
 task assembleFfmpeg(type: Exec) {
     def host = ""
-    if (Os.isFamily(Os.FAMILY_UNIX)) {
-        host = "linux-x86_64"
-    } else if (Os.isFamily(Os.FAMILY_MAC)) {
+    if (Os.isFamily(Os.FAMILY_MAC)) {
         host = "darwin-x86_64"
+    } else if (Os.isFamily(Os.FAMILY_UNIX)) {
+        host = "linux-x86_64"
     } else {
         throw UnsupportedOperationException(
                 "Building with Windows is not supported. " +


### PR DESCRIPTION
Change to `decoder_ffmpeg`'s build script to fix OxygenCobalt/Auxio#742. Please let me know if I'm merging into the wrong branch!

I've built [a debug APK](https://github.com/OxygenCobalt/media/files/14706338/auxio-debug.zip) for Auxio using my media3 fork in case you want to test anything. On my MacBook I've run the local and instrumented unit tests for Auxio/media3 and they all seemed to pass. I ran the instrumented tests in the Android Emulator, using a Pixel 3a AVD running Android 14 (API level 34). There was one ExoPlayer test related to Clearkey DRM that seemed to fail on a Tiramisu AVD: not sure if this is a cause for concern?

I also tried to build a debug APK of Auxio within an Ubuntu 23.10 VM and didn't seem to run into any issues. I wasn't able to get some of the ExoPlayer tests to run within my VM though (I hit an 'unimplemented' error when ExoPlayer attempted to create an image decoder), so it may be useful to test on a bare metal Linux machine if you want more certainty.

Let me know if you need me to change anything or give any more detail.